### PR TITLE
If there are other cookies exist like 'session=sessionvalue; X-Experiment=5', getCookie will fail to find the X-Experiment cookie key as there is extra space.

### DIFF
--- a/resources/module_3_1/request/index.js
+++ b/resources/module_3_1/request/index.js
@@ -80,7 +80,7 @@ const getCookie = (headers, cookieKey) => {
       const cookies = cookieHeader.value.split(';');
       for (let cookie of cookies) {
         const [key, val] = cookie.split('=');
-        if (key === cookieKey) {
+        if (key.trim() === cookieKey) {
           return val;
         }
       }

--- a/resources/module_3_1/response/index.js
+++ b/resources/module_3_1/response/index.js
@@ -24,7 +24,7 @@ const getCookie = (headers, cookieKey) => {
             const cookies = cookieHeader.value.split(';');
             for (let cookie of cookies) {
                 const [key, val] = cookie.split('=');
-                if (key === cookieKey) {
+                if (key.trim() === cookieKey) {
                     return val;
                 }
             }
@@ -52,7 +52,7 @@ exports.handler = async event => {
     if (cookieVal) {
         console.log(`setting cookie ${COOKIE_KEY}=${cookieVal}`);
         setCookie(response, `${COOKIE_KEY}=${cookieVal}`);
-    }else{
+    } else {
         console.log(`no ${COOKIE_KEY} cookie`);
     }
 

--- a/resources/module_3_2/request/index.js
+++ b/resources/module_3_2/request/index.js
@@ -64,7 +64,7 @@ const getCookie = (headers, cookieKey) => {
       const cookies = cookieHeader.value.split(';');
       for (let cookie of cookies) {
         const [key, val] = cookie.split('=');
-        if (key === cookieKey) {
+        if (key.trim() === cookieKey) {
           return val;
         }
       }

--- a/resources/module_3_2/response/index.js
+++ b/resources/module_3_2/response/index.js
@@ -24,7 +24,7 @@ const getCookie = (headers, cookieKey) => {
             const cookies = cookieHeader.value.split(';');
             for (let cookie of cookies) {
                 const [key, val] = cookie.split('=');
-                if (key === cookieKey) {
+                if (key.trim() === cookieKey) {
                     return val;
                 }
             }
@@ -52,7 +52,7 @@ exports.handler = async event => {
     if (cookieVal) {
         console.log(`setting cookie ${COOKIE_KEY}=${cookieVal}`);
         setCookie(response, `${COOKIE_KEY}=${cookieVal}`);
-    }else{
+    } else {
         console.log(`no ${COOKIE_KEY} cookie`);
     }
     return response;

--- a/resources/module_3_3/request/index.js
+++ b/resources/module_3_3/request/index.js
@@ -63,7 +63,7 @@ const getCookie = (headers, cookieKey) => {
       const cookies = cookieHeader.value.split(';');
       for (let cookie of cookies) {
         const [key, val] = cookie.split('=');
-        if (key === cookieKey) {
+        if (key.trim() === cookieKey) {
           return val;
         }
       }

--- a/resources/module_3_3/response/index.js
+++ b/resources/module_3_3/response/index.js
@@ -24,7 +24,7 @@ const getCookie = (headers, cookieKey) => {
             const cookies = cookieHeader.value.split(';');
             for (let cookie of cookies) {
                 const [key, val] = cookie.split('=');
-                if (key === cookieKey) {
+                if (key.trim() === cookieKey) {
                     return val;
                 }
             }
@@ -52,7 +52,7 @@ exports.handler = async event => {
     if (cookieVal) {
         console.log(`setting cookie ${COOKIE_KEY}=${cookieVal}`);
         setCookie(response, `${COOKIE_KEY}=${cookieVal}`);
-    }else{
+    } else {
         console.log(`no ${COOKIE_KEY} cookie`);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Sometimes returning users will be treated as new users and new X-Experiment values will be sent back in HTTP response even there is X-Experiment cookie in HTTP request

*Description of changes:*
drop extra space in the cookie key before comparison and this fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
